### PR TITLE
Add Support for Disabling Signature Verification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,21 @@
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
         </service>
+
+        <service
+            android:name=".SignatureQuickTile"
+            android:exported="true"
+            android:icon="@drawable/ic_baseline_verified_user_24"
+            android:label="@string/signature_tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/berdik/letmedowngrade/LetMeDowngrade.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/LetMeDowngrade.kt
@@ -2,6 +2,7 @@ package com.berdik.letmedowngrade
 
 import android.util.Log
 import com.berdik.letmedowngrade.hookers.PackageManagerServiceHooker
+import com.berdik.letmedowngrade.hookers.SignatureVerificationHooker
 import io.github.libxposed.api.XposedModule
 import io.github.libxposed.api.XposedModuleInterface.ModuleLoadedParam
 import io.github.libxposed.api.XposedModuleInterface.SystemServerStartingParam
@@ -21,6 +22,12 @@ class LetMeDowngrade : XposedModule() {
 
         try {
             PackageManagerServiceHooker.hook(param, this)
+        } catch (e: Exception) {
+            log(Log.ERROR, TAG, "ERROR: $e")
+        }
+
+        try {
+            SignatureVerificationHooker.hook(param, this)
         } catch (e: Exception) {
             log(Log.ERROR, TAG, "ERROR: $e")
         }

--- a/app/src/main/java/com/berdik/letmedowngrade/MainActivity.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/MainActivity.kt
@@ -52,6 +52,7 @@ import com.berdik.letmedowngrade.utils.XposedChecker
 class MainActivity : ComponentActivity() {
 
     private lateinit var isHookSwitchOn: MutableState<Boolean>
+    private lateinit var isSignatureBypassSwitchOn: MutableState<Boolean>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -59,9 +60,15 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         PrefManager.loadPrefs()
         isHookSwitchOn = mutableStateOf(PrefManager.isHookOn())
+        isSignatureBypassSwitchOn = mutableStateOf(PrefManager.isSignatureBypassOn())
         PrefManager.getHookActiveAsLiveData().observe(this) { isActive ->
             isActive?.let {
                 isHookSwitchOn.value = it
+            }
+        }
+        PrefManager.getSignatureBypassActiveAsLiveData().observe(this) { isActive ->
+            isActive?.let {
+                isSignatureBypassSwitchOn.value = it
             }
         }
 
@@ -114,63 +121,87 @@ class MainActivity : ComponentActivity() {
                 verticalArrangement = Arrangement.spacedBy(20.dp),
                 horizontalAlignment = Alignment.Start
             ) {
-                StatusCard(isHookSwitchOn)
+                if (!XposedChecker.isEnabled()) {
+                    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.error_24),
+                                contentDescription = stringResource(R.string.error_icon_content_description)
+                            )
+                            Text(
+                                text = stringResource(R.string.module_disabled),
+                                fontSize = 20.sp,
+                                textAlign = TextAlign.Start,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+                StatusCard(
+                    title = stringResource(R.string.status_title),
+                    enabledText = stringResource(R.string.downgrade_status_enabled),
+                    disabledText = stringResource(R.string.downgrade_status_disabled),
+                    isSwitchOn = isHookSwitchOn,
+                    onToggle = { PrefManager.toggleHookState() }
+                )
+                StatusCard(
+                    title = stringResource(R.string.signature_status_title),
+                    enabledText = stringResource(R.string.signature_status_enabled),
+                    disabledText = stringResource(R.string.signature_status_disabled),
+                    isSwitchOn = isSignatureBypassSwitchOn,
+                    onToggle = { PrefManager.toggleSignatureBypassState() }
+                )
             }
         }
     }
 
     @Composable
-    fun StatusCard(isHookSwitchOn: MutableState<Boolean>) {
+    fun StatusCard(
+        title: String,
+        enabledText: String,
+        disabledText: String,
+        isSwitchOn: MutableState<Boolean>,
+        onToggle: () -> Unit
+    ) {
         OutlinedCard(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    if (XposedChecker.isEnabled()) {
-                        Icon(
-                            painterResource(R.drawable.checklist_24),
-                            contentDescription = stringResource(R.string.status_icon_content_description)
-                        )
-                    } else {
-                        Icon(
-                            painterResource(R.drawable.error_24),
-                            contentDescription = stringResource(R.string.error_icon_content_description)
-                        )
-                    }
+                    Icon(
+                        painterResource(R.drawable.checklist_24),
+                        contentDescription = stringResource(R.string.status_icon_content_description)
+                    )
                     Text(
-                        text = stringResource(R.string.status_title),
+                        text = title,
                         fontSize = 24.sp,
                         color = MaterialTheme.colorScheme.onSurface
                     )
                 }
 
-                if (!XposedChecker.isEnabled()) {
-                    Text(
-                        text = stringResource(R.string.module_disabled),
-                        fontSize = 20.sp,
-                        textAlign = TextAlign.Start,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(10.dp)
-                    )
-                } else {
+                if (XposedChecker.isEnabled()) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(
-                            text = if (isHookSwitchOn.value) {
-                                stringResource(R.string.downgrade_status_enabled)
+                            text = if (isSwitchOn.value) {
+                                enabledText
                             } else {
-                                stringResource(R.string.downgrade_status_disabled)
+                                disabledText
                             },
                             fontSize = 16.sp,
                             color = MaterialTheme.colorScheme.onSurface
                         )
                         Switch(
-                            checked = isHookSwitchOn.value,
-                            onCheckedChange = { PrefManager.toggleHookState() },
+                            checked = isSwitchOn.value,
+                            onCheckedChange = { onToggle() },
                             modifier = Modifier.padding(10.dp)
                         )
                     }

--- a/app/src/main/java/com/berdik/letmedowngrade/MainActivity.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/MainActivity.kt
@@ -121,51 +121,15 @@ class MainActivity : ComponentActivity() {
                 verticalArrangement = Arrangement.spacedBy(20.dp),
                 horizontalAlignment = Alignment.Start
             ) {
-                if (!XposedChecker.isEnabled()) {
-                    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(10.dp),
-                            modifier = Modifier.padding(16.dp)
-                        ) {
-                            Icon(
-                                painterResource(R.drawable.error_24),
-                                contentDescription = stringResource(R.string.error_icon_content_description)
-                            )
-                            Text(
-                                text = stringResource(R.string.module_disabled),
-                                fontSize = 20.sp,
-                                textAlign = TextAlign.Start,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
-                    }
-                }
-                StatusCard(
-                    title = stringResource(R.string.status_title),
-                    enabledText = stringResource(R.string.downgrade_status_enabled),
-                    disabledText = stringResource(R.string.downgrade_status_disabled),
-                    isSwitchOn = isHookSwitchOn,
-                    onToggle = { PrefManager.toggleHookState() }
-                )
-                StatusCard(
-                    title = stringResource(R.string.signature_status_title),
-                    enabledText = stringResource(R.string.signature_status_enabled),
-                    disabledText = stringResource(R.string.signature_status_disabled),
-                    isSwitchOn = isSignatureBypassSwitchOn,
-                    onToggle = { PrefManager.toggleSignatureBypassState() }
-                )
+                StatusCard(isHookSwitchOn, isSignatureBypassSwitchOn)
             }
         }
     }
 
     @Composable
     fun StatusCard(
-        title: String,
-        enabledText: String,
-        disabledText: String,
-        isSwitchOn: MutableState<Boolean>,
-        onToggle: () -> Unit
+        isHookSwitchOn: MutableState<Boolean>,
+        isSignatureBypassSwitchOn: MutableState<Boolean>
     ) {
         OutlinedCard(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp)) {
@@ -173,40 +137,76 @@ class MainActivity : ComponentActivity() {
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    Icon(
-                        painterResource(R.drawable.checklist_24),
-                        contentDescription = stringResource(R.string.status_icon_content_description)
-                    )
+                    if (XposedChecker.isEnabled()) {
+                        Icon(
+                            painterResource(R.drawable.checklist_24),
+                            contentDescription = stringResource(R.string.status_icon_content_description)
+                        )
+                    } else {
+                        Icon(
+                            painterResource(R.drawable.error_24),
+                            contentDescription = stringResource(R.string.error_icon_content_description)
+                        )
+                    }
                     Text(
-                        text = title,
+                        text = stringResource(R.string.status_title),
                         fontSize = 24.sp,
                         color = MaterialTheme.colorScheme.onSurface
                     )
                 }
 
-                if (XposedChecker.isEnabled()) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            text = if (isSwitchOn.value) {
-                                enabledText
-                            } else {
-                                disabledText
-                            },
-                            fontSize = 16.sp,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Switch(
-                            checked = isSwitchOn.value,
-                            onCheckedChange = { onToggle() },
-                            modifier = Modifier.padding(10.dp)
-                        )
-                    }
+                if (!XposedChecker.isEnabled()) {
+                    Text(
+                        text = stringResource(R.string.module_disabled),
+                        fontSize = 20.sp,
+                        textAlign = TextAlign.Start,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(10.dp)
+                    )
+                } else {
+                    SettingRow(
+                        enabledText = stringResource(R.string.downgrade_status_enabled),
+                        disabledText = stringResource(R.string.downgrade_status_disabled),
+                        isSwitchOn = isHookSwitchOn,
+                        onToggle = { PrefManager.toggleHookState() }
+                    )
+                    SettingRow(
+                        enabledText = stringResource(R.string.signature_status_enabled),
+                        disabledText = stringResource(R.string.signature_status_disabled),
+                        isSwitchOn = isSignatureBypassSwitchOn,
+                        onToggle = { PrefManager.toggleSignatureBypassState() }
+                    )
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun SettingRow(
+        enabledText: String,
+        disabledText: String,
+        isSwitchOn: MutableState<Boolean>,
+        onToggle: () -> Unit
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = if (isSwitchOn.value) {
+                    enabledText
+                } else {
+                    disabledText
+                },
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Switch(
+                checked = isSwitchOn.value,
+                onCheckedChange = { onToggle() },
+                modifier = Modifier.padding(10.dp)
+            )
         }
     }
 

--- a/app/src/main/java/com/berdik/letmedowngrade/SignatureQuickTile.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/SignatureQuickTile.kt
@@ -1,0 +1,27 @@
+package com.berdik.letmedowngrade
+
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import com.berdik.letmedowngrade.utils.PrefManager
+
+class SignatureQuickTile : TileService() {
+    override fun onStartListening() {
+        super.onStartListening()
+        PrefManager.loadPrefs()
+        setButtonState()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        PrefManager.toggleSignatureBypassState()
+        setButtonState()
+    }
+
+    private fun setButtonState() {
+        if (PrefManager.isSignatureBypassOn())
+            qsTile.state = Tile.STATE_ACTIVE
+        else
+            qsTile.state = Tile.STATE_INACTIVE
+        qsTile.updateTile()
+    }
+}

--- a/app/src/main/java/com/berdik/letmedowngrade/hookers/SignatureVerificationHooker.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/hookers/SignatureVerificationHooker.kt
@@ -1,0 +1,355 @@
+package com.berdik.letmedowngrade.hookers
+
+import android.annotation.SuppressLint
+import android.util.Log
+import com.berdik.letmedowngrade.BuildConfig
+import com.berdik.letmedowngrade.TAG
+import io.github.libxposed.api.XposedModule
+import io.github.libxposed.api.XposedModuleInterface.SystemServerStartingParam
+import java.util.Arrays
+
+class SignatureVerificationHooker {
+    companion object {
+        private const val PREF_KEY = "signatureBypassActive"
+        private const val PERMISSION_CAPABILITY = 4
+        private const val AUTH_CAPABILITY = 16
+
+        var module: XposedModule? = null
+            private set
+
+        private val keySetBypass = ThreadLocal<Boolean>()
+
+        fun hook(param: SystemServerStartingParam, module: XposedModule) {
+            this.module = module
+            val classLoader = param.classLoader
+
+            hookSigningDetails(classLoader, module)
+            hookStrictJarVerifier(classLoader, module)
+            hookPackageManagerServiceUtils(classLoader, module)
+            hookKeySetManagerService(classLoader, module)
+            hookMessageDigest(classLoader, module)
+            hookApkSigningBlockUtils(classLoader, module)
+            hookApkSignatureVerifier(classLoader, module)
+            hookScanPackageUtils(classLoader, module)
+        }
+
+        private fun isBypassActive(module: XposedModule): Boolean {
+            return module.getRemotePreferences(BuildConfig.APPLICATION_ID)
+                .getBoolean(PREF_KEY, false)
+        }
+
+        private fun hookSigningDetails(classLoader: ClassLoader, module: XposedModule) {
+            val signingDetailsClass = findSigningDetailsClass(classLoader) ?: return
+
+            try {
+                val checkCapabilityMethod = signingDetailsClass.getDeclaredMethod(
+                    "checkCapability", signingDetailsClass, Int::class.javaPrimitiveType
+                )
+                module.hook(checkCapabilityMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        val flags = chain.args[1] as Int
+                        if (flags != PERMISSION_CAPABILITY && flags != AUTH_CAPABILITY) {
+                            module.log(Log.INFO, TAG, "Bypassed checkCapability")
+                            return@intercept true
+                        }
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook checkCapability: $e")
+            }
+
+            try {
+                val checkCapabilityRecoverMethod = signingDetailsClass.getDeclaredMethod(
+                    "checkCapabilityRecover", signingDetailsClass, Int::class.javaPrimitiveType
+                )
+                module.hook(checkCapabilityRecoverMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        val flags = chain.args[1] as Int
+                        if (flags != PERMISSION_CAPABILITY && flags != AUTH_CAPABILITY) {
+                            module.log(Log.INFO, TAG, "Bypassed checkCapabilityRecover")
+                            return@intercept true
+                        }
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook checkCapabilityRecover: $e")
+            }
+
+            try {
+                val signaturesMatchExactlyMethod = signingDetailsClass.getDeclaredMethod(
+                    "signaturesMatchExactly", signingDetailsClass
+                )
+                module.hook(signaturesMatchExactlyMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        module.log(Log.INFO, TAG, "Bypassed signaturesMatchExactly")
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook signaturesMatchExactly: $e")
+            }
+
+            try {
+                val hasCommonAncestorMethod = signingDetailsClass.getDeclaredMethod(
+                    "hasCommonAncestor", signingDetailsClass
+                )
+                module.hook(hasCommonAncestorMethod).intercept { chain ->
+                    if (isBypassActive(module) && isCalledFromVerifySignatures()) {
+                        module.log(Log.INFO, TAG, "Bypassed hasCommonAncestor")
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+            } catch (_: Exception) {}
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookStrictJarVerifier(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val strictJarVerifierClass = classLoader.loadClass("android.util.jar.StrictJarVerifier")
+
+                val verifyMessageDigestMethod = strictJarVerifierClass.declaredMethods.first { method ->
+                    method.name == "verifyMessageDigest" && method.returnType == Boolean::class.javaPrimitiveType
+                }
+                module.hook(verifyMessageDigestMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+
+                val verifyMethod = strictJarVerifierClass.declaredMethods.first { method ->
+                    method.name == "verify" && method.returnType == Boolean::class.javaPrimitiveType
+                }
+                module.hook(verifyMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+
+                val constructor = strictJarVerifierClass.declaredConstructors.first()
+                val rollbackField = strictJarVerifierClass.declaredFields.first { field ->
+                    field.name == "signatureSchemeRollbackProtectionsEnforced"
+                }
+                rollbackField.isAccessible = true
+                module.hook(constructor).intercept { chain ->
+                    val result = chain.proceed()
+                    if (isBypassActive(module)) {
+                        rollbackField.set(chain.thisObject, false)
+                    }
+                    result
+                }
+
+                hookVerifyBytes(classLoader, module, strictJarVerifierClass)
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook StrictJarVerifier: $e")
+            }
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookVerifyBytes(
+            classLoader: ClassLoader,
+            module: XposedModule,
+            strictJarVerifierClass: Class<*>
+        ) {
+            try {
+                val verifyBytesMethod = strictJarVerifierClass.getDeclaredMethod(
+                    "verifyBytes", ByteArray::class.java, ByteArray::class.java
+                )
+                val pkcs7Class = classLoader.loadClass("sun.security.pkcs.PKCS7")
+                val pkcs7Constructor = pkcs7Class.declaredConstructors.first { constructor ->
+                    constructor.parameterTypes.size == 1 &&
+                        constructor.parameterTypes[0] == ByteArray::class.java
+                }
+                val getSignerInfosMethod = pkcs7Class.getDeclaredMethod("getSignerInfos")
+                val signerInfoClass = classLoader.loadClass("sun.security.pkcs.SignerInfo")
+                val getCertificateChainMethod = signerInfoClass.getDeclaredMethod(
+                    "getCertificateChain", pkcs7Class
+                )
+
+                module.hook(verifyBytesMethod).intercept { chain ->
+                    val result = chain.proceed()
+                    if (isBypassActive(module)) {
+                        try {
+                            val block = pkcs7Constructor.newInstance(chain.args[0])
+                            val signerInfos = getSignerInfosMethod.invoke(block) as Array<*>
+                            if (signerInfos.isNotEmpty()) {
+                                val certs = getCertificateChainMethod.invoke(signerInfos[0], block)
+                                return@intercept certs
+                            }
+                        } catch (e: Exception) {
+                            module.log(Log.ERROR, TAG, "verifyBytes bypass failed: $e")
+                        }
+                    }
+                    result
+                }
+            } catch (_: Exception) {}
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookPackageManagerServiceUtils(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val utilsClass = classLoader.loadClass("com.android.server.pm.PackageManagerServiceUtils")
+                val verifySignaturesMethod = utilsClass.declaredMethods.first { method ->
+                    method.name == "verifySignatures" && method.returnType == Boolean::class.javaPrimitiveType
+                }
+                module.deoptimize(verifySignaturesMethod)
+                module.hook(verifySignaturesMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        module.log(Log.INFO, TAG, "Bypassed verifySignatures")
+                        return@intercept false
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook verifySignatures: $e")
+            }
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookKeySetManagerService(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val keySetClass = classLoader.loadClass("com.android.server.pm.KeySetManagerService")
+
+                val shouldCheckMethod = keySetClass.declaredMethods.first { method ->
+                    method.name == "shouldCheckUpgradeKeySetLocked" &&
+                        method.returnType == Boolean::class.javaPrimitiveType
+                }
+                module.hook(shouldCheckMethod).intercept { chain ->
+                    if (isBypassActive(module) && isCalledFromInstallFlow()) {
+                        keySetBypass.set(true)
+                        return@intercept true
+                    }
+                    keySetBypass.set(false)
+                    chain.proceed()
+                }
+
+                val checkUpgradeMethod = keySetClass.declaredMethods.first { method ->
+                    method.name == "checkUpgradeKeySetLocked" &&
+                        method.returnType == Boolean::class.javaPrimitiveType
+                }
+                module.hook(checkUpgradeMethod).intercept { chain ->
+                    if (isBypassActive(module) && keySetBypass.get() == true) {
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook KeySetManagerService: $e")
+            }
+        }
+
+        private fun hookMessageDigest(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val messageDigestClass = classLoader.loadClass("java.security.MessageDigest")
+                val isEqualMethod = messageDigestClass.getDeclaredMethod(
+                    "isEqual", ByteArray::class.java, ByteArray::class.java
+                )
+                module.hook(isEqualMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept true
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook MessageDigest.isEqual: $e")
+            }
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookApkSigningBlockUtils(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val utilsClass = classLoader.loadClass("android.util.apk.ApkSigningBlockUtils")
+
+                val parseVerityMethod = utilsClass.declaredMethods.first { method ->
+                    method.name == "parseVerityDigestAndVerifySourceLength"
+                }
+                module.hook(parseVerityMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        val digest = chain.args[0] as ByteArray
+                        return@intercept digest.copyOfRange(0, minOf(32, digest.size))
+                    }
+                    chain.proceed()
+                }
+
+                val verifyIntegrityMethod = utilsClass.declaredMethods.first { method ->
+                    method.name == "verifyIntegrityForVerityBasedAlgorithm"
+                }
+                module.hook(verifyIntegrityMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept null
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook ApkSigningBlockUtils: $e")
+            }
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookApkSignatureVerifier(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val verifierClass = classLoader.loadClass("android.util.apk.ApkSignatureVerifier")
+                val getMinSchemeMethod = verifierClass.getDeclaredMethod(
+                    "getMinimumSignatureSchemeVersionForTargetSdk", Int::class.javaPrimitiveType
+                )
+                module.hook(getMinSchemeMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept 0
+                    }
+                    chain.proceed()
+                }
+            } catch (e: Exception) {
+                module.log(Log.ERROR, TAG, "Failed to hook ApkSignatureVerifier: $e")
+            }
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun hookScanPackageUtils(classLoader: ClassLoader, module: XposedModule) {
+            try {
+                val scanUtilsClass = classLoader.loadClass("com.android.server.pm.ScanPackageUtils")
+                val assertMethod = scanUtilsClass.declaredMethods.first { method ->
+                    method.name == "assertMinSignatureSchemeIsValid"
+                }
+                module.hook(assertMethod).intercept { chain ->
+                    if (isBypassActive(module)) {
+                        return@intercept null
+                    }
+                    chain.proceed()
+                }
+            } catch (_: Exception) {}
+        }
+
+        @SuppressLint("PrivateApi")
+        private fun findSigningDetailsClass(classLoader: ClassLoader): Class<*>? {
+            try {
+                return classLoader.loadClass("android.content.pm.SigningDetails")
+            } catch (_: Exception) {}
+
+            try {
+                return classLoader.loadClass("android.content.pm.PackageParser\$SigningDetails")
+            } catch (_: Exception) {}
+
+            return null
+        }
+
+        private fun isCalledFromVerifySignatures(): Boolean {
+            return Arrays.stream(Thread.currentThread().stackTrace)
+                .anyMatch { element -> element.methodName == "verifySignatures" }
+        }
+
+        private fun isCalledFromInstallFlow(): Boolean {
+            return Arrays.stream(Thread.currentThread().stackTrace)
+                .anyMatch { element ->
+                    element.methodName == "preparePackage" ||
+                        element.methodName == "reconcileInstallPackages" ||
+                        element.methodName == "preparePackageLI" ||
+                        element.methodName == "installPackageLI"
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/berdik/letmedowngrade/utils/PrefManager.kt
+++ b/app/src/main/java/com/berdik/letmedowngrade/utils/PrefManager.kt
@@ -8,15 +8,22 @@ import io.github.libxposed.service.XposedService
 import io.github.libxposed.service.XposedServiceHelper
 
 object PrefManager {
+    private const val HOOK_ACTIVE_KEY = "hookActive"
+    private const val SIGNATURE_BYPASS_ACTIVE_KEY = "signatureBypassActive"
+
     private var prefs: SharedPreferences? = null
     private val hookActiveLiveData = MutableLiveData<Boolean>()
+    private val signatureBypassActiveLiveData = MutableLiveData<Boolean>()
 
     fun loadPrefs() {
         XposedServiceHelper.registerListener(object : XposedServiceHelper.OnServiceListener {
             override fun onServiceBind(service: XposedService) {
                 XposedChecker.flagAsEnabled()
                 prefs = service.getRemotePreferences(BuildConfig.APPLICATION_ID)
-                hookActiveLiveData.postValue(prefs!!.getBoolean("hookActive", false))
+                hookActiveLiveData.postValue(prefs!!.getBoolean(HOOK_ACTIVE_KEY, false))
+                signatureBypassActiveLiveData.postValue(
+                    prefs!!.getBoolean(SIGNATURE_BYPASS_ACTIVE_KEY, false)
+                )
             }
 
             override fun onServiceDied(service: XposedService) {}
@@ -28,7 +35,7 @@ object PrefManager {
             return false
         }
         hookActiveLiveData.value?.let { return it }
-        return prefs?.getBoolean("hookActive", false) ?: false
+        return prefs?.getBoolean(HOOK_ACTIVE_KEY, false) ?: false
     }
 
     fun toggleHookState() {
@@ -37,15 +44,41 @@ object PrefManager {
         }
     }
 
+    fun isSignatureBypassOn(): Boolean {
+        if (!XposedChecker.isEnabled()) {
+            return false
+        }
+        signatureBypassActiveLiveData.value?.let { return it }
+        return prefs?.getBoolean(SIGNATURE_BYPASS_ACTIVE_KEY, false) ?: false
+    }
+
+    fun toggleSignatureBypassState() {
+        if (XposedChecker.isEnabled()) {
+            setSignatureBypassState(!isSignatureBypassOn())
+        }
+    }
+
     @SuppressLint("ApplySharedPref")
     private fun setHookState(prefVal: Boolean) {
         if (XposedChecker.isEnabled() && prefs != null) {
             hookActiveLiveData.value = prefVal
-            prefs!!.edit().putBoolean("hookActive", prefVal).commit()
+            prefs!!.edit().putBoolean(HOOK_ACTIVE_KEY, prefVal).commit()
+        }
+    }
+
+    @SuppressLint("ApplySharedPref")
+    private fun setSignatureBypassState(prefVal: Boolean) {
+        if (XposedChecker.isEnabled() && prefs != null) {
+            signatureBypassActiveLiveData.value = prefVal
+            prefs!!.edit().putBoolean(SIGNATURE_BYPASS_ACTIVE_KEY, prefVal).commit()
         }
     }
 
     fun getHookActiveAsLiveData(): MutableLiveData<Boolean> {
         return hookActiveLiveData
+    }
+
+    fun getSignatureBypassActiveAsLiveData(): MutableLiveData<Boolean> {
+        return signatureBypassActiveLiveData
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_verified_user_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_verified_user_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5l-9,-4zM10,17l-4,-4 1.41,-1.41L10,14.17l6.59,-6.59L18,9l-8,8z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="tile_label">App Downgrades</string>
     <string name="signature_tile_label">Signature Verification</string>
     <string name="status_title">Status</string>
-    <string name="signature_status_title">Signature Verification</string>
     <string name="status_icon_content_description">Status</string>
     <string name="error_icon_content_description">Error</string>
     <string name="module_disabled">Let Me Downgrade is not enabled. Please enable it in the LSPosed Manager, reboot your device, and try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Let Me Downgrade</string>
-    <string name="xposed_description">Add support for downgrading apps on Android 12 through 17.</string>
+    <string name="xposed_description">Add support for downgrading apps and disabling signature verification on Android 12 through 17.</string>
     <string name="tile_label">App Downgrades</string>
+    <string name="signature_tile_label">Signature Verification</string>
     <string name="status_title">Status</string>
+    <string name="signature_status_title">Signature Verification</string>
     <string name="status_icon_content_description">Status</string>
     <string name="error_icon_content_description">Error</string>
     <string name="module_disabled">Let Me Downgrade is not enabled. Please enable it in the LSPosed Manager, reboot your device, and try again.</string>
     <string name="downgrade_status_enabled">App downgrades allowed</string>
     <string name="downgrade_status_disabled">App downgrades blocked</string>
+    <string name="signature_status_enabled">Signature verification disabled</string>
+    <string name="signature_status_disabled">Signature verification enabled</string>
 </resources>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add support for disabling signature verification.

This implements signature verification bypass using hook patterns adapted from [CorePatch](https://github.com/LSPosed/CorePatch), with an in-app switch and quick settings tile matching the existing downgrade feature layout.

## Changes

- **`SignatureVerificationHooker`** — Hooks system_server methods to bypass signature checks when enabled:
  - `SigningDetails` — `checkCapability`, `checkCapabilityRecover`, `signaturesMatchExactly`, `hasCommonAncestor`
  - `StrictJarVerifier` — digest and certificate verification
  - `PackageManagerServiceUtils.verifySignatures`
  - `KeySetManagerService` — upgrade key set checks during install
  - `MessageDigest.isEqual`
  - `ApkSigningBlockUtils` — verity digest checks
  - `ApkSignatureVerifier.getMinimumSignatureSchemeVersionForTargetSdk`
  - `ScanPackageUtils.assertMinSignatureSchemeIsValid`
- **`PrefManager`** — New `signatureBypassActive` preference with LiveData support
- **`MainActivity`** — Single status card with both toggles (matching [CaptureSposed](https://github.com/99keshav99/CaptureSposed/) layout)
- **`SignatureQuickTile`** — Quick settings tile to toggle signature bypass
- **Strings and manifest** — Labels and tile registration

## Usage

1. Enable the module in LSPosed (scope: `system`) and reboot
2. Toggle signature verification bypass from the app or the "Signature Verification" quick settings tile
3. Install APKs with mismatched or modified signatures

The downgrade and signature bypass toggles are independent — either or both can be enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d94e3e96-6151-4573-b313-9288da78e30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d94e3e96-6151-4573-b313-9288da78e30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

